### PR TITLE
Add configuration option for Blueutil behavior selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,19 @@ Search your paired bluetooth devices via the `btd` keyword. Press <kbd>↩&#xFE0
 Toggle bluetooth as a whole via the `btt` keyword. Configure the [Hotkey](https://www.alfredapp.com/help/workflows/triggers/hotkey/) for faster toggling.
 
 ![Connect or disconnect bluetooth](Workflow/images/about/btt.png)
+
+## Requirements
+
+- macOS with Bluetooth capability
+- [blueutil](https://github.com/toy/blueutil) 2.10.0+ (installed automatically with workflow)
+- blueutil 2.13.0+ required for System Profiler option
+
+## Configuration
+
+Access workflow configuration by right-clicking the workflow in Alfred Preferences → Workflows.
+
+### Available Options
+
+- **Device Toggle Keyword**: Customize the keyword for device operations (default: `btd`)
+- **Bluetooth Toggle Keyword**: Customize the keyword for Bluetooth power toggle (default: `btt`)
+- **Use System Profiler for Device Queries**: Enable experimental mode to fix multipoint devices appearing disconnected when connected (requires blueutil 2.13.0+)

--- a/Workflow/info.plist
+++ b/Workflow/info.plist
@@ -578,11 +578,26 @@ Toggle bluetooth as a whole via the `btt` keyword. Configure the [Hotkey](https:
 			<key>variable</key>
 			<string>full_toggle_keyword</string>
 		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<false/>
+			</dict>
+			<key>description</key>
+			<string>EXPERIMENTAL: Use system_profiler for paired device queries. Fixes multipoint devices appearing disconnected when connected (requires blueutil 2.13.0+)</string>
+			<key>label</key>
+			<string>Use System Profiler for Device Queries</string>
+			<key>type</key>
+			<string>checkbox</string>
+			<key>variable</key>
+			<string>BLUEUTIL_USE_SYSTEM_PROFILER</string>
+		</dict>
 	</array>
 	<key>variablesdontexport</key>
 	<array/>
 	<key>version</key>
-	<string>2024.1</string>
+	<string>2024.2</string>
 	<key>webaddress</key>
 	<string>https://github.com/vitorgalvao/dente-azul-workflow/</string>
 </dict>


### PR DESCRIPTION
This PR introduces a new configuration setting in the Alfred workflow that allows users to choose between two Blueutil behaviors:

Default behavior (existing): Uses the `IOBluetooth` interface to retrieve device status
Experimental behavior (new): Uses system profiler to determine connection status of Bluetooth devices

The experimental behavior requires Blueutil version 1.23.0 or higher.

This new option addresses connectivity issues with multipoint Bluetooth devices that may report incorrect connection status through the standard `IOBluetooth` interface. Users can now work around scenarios where devices appear disconnected in Blueutil despite being actively connected to the system.
